### PR TITLE
Support for Silverstripe CMS 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ composer require gorriecoe/silverstripe-gtm
 
 ## Requirements
 
-- silverstripe/cmframework ^4.0
+- `silverstripe/cms: ^5`
 
 ## Maintainers
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "homepage": "http://github.com/gorriecoe/silverstripe-gtm",
   "require": {
-    "silverstripe/framework": "^4.0"
+    "silverstripe/framework": "^5"
   },
   "extra": {
     "installer-name": "gtm"

--- a/src/extensions/GTMConfig.php
+++ b/src/extensions/GTMConfig.php
@@ -5,7 +5,7 @@ namespace gorriecoe\GTM\Extensions;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\LiteralField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\Core\Environment;
 
 /**
@@ -13,7 +13,7 @@ use SilverStripe\Core\Environment;
  *
  * @package silverstripe-gtm
  */
-class GTMConfig extends DataExtension
+class GTMConfig extends Extension
 {
     /**
      * Database fields


### PR DESCRIPTION
- Updates to `composer.json` to support `"silverstripe/framework": "^5"`
- Updates to `ReadMe.md` 
- Updates to deprecated `DataExtension` class, now swapped for `Extension`